### PR TITLE
feat(decoder): add initial skeleton for file decoder

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,0 +1,66 @@
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+use std::fs;
+use thiserror::Error;
+use toml::Value as TomlValue;
+
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("-------------------------------------\n{0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("-------------------------------------\n{0}")]
+    Json(#[from] serde_json::Error),
+    #[error("-------------------------------------\n{0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error("File read error: {0}")]
+    FileRead(#[from] std::io::Error),
+}
+
+// TODO: INI, YAML
+#[derive(strum_macros::Display)]
+pub enum Decoder {
+    TOML,
+    JSON,
+    YAML,
+}
+
+impl Decoder {
+    fn verify_file_extension(&self, file_path: &str) -> bool {
+        match self {
+            Decoder::TOML => file_path.ends_with(".toml"),
+            Decoder::JSON => file_path.ends_with(".json"),
+            Decoder::YAML => file_path.ends_with(".yaml") || file_path.ends_with(".yml"),
+        }
+    }
+
+    pub fn decode_from_str(&self, content: &str) -> Result<JsonValue, DecodeError> {
+        match self {
+            Decoder::TOML => {
+                let toml_value: TomlValue = content.parse()?;
+                let json_value = serde_json::to_value(toml_value)?;
+                Ok(json_value)
+            }
+            Decoder::JSON => {
+                let json_value: JsonValue = serde_json::from_str(content)?;
+                Ok(json_value)
+            }
+            Decoder::YAML => {
+                let yaml_value: YamlValue = serde_yaml::from_str(content)?;
+                let json_value = serde_json::to_value(yaml_value)?;
+                Ok(json_value)
+            }
+        }
+    }
+
+    pub fn decode_file(&self, file_path: &str) -> Result<JsonValue, DecodeError> {
+        if !self.verify_file_extension(file_path) {
+            return Err(DecodeError::FileRead(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid file extension",
+            )));
+        }
+
+        let content = fs::read_to_string(file_path)?;
+        self.decode_from_str(&content)
+    }
+}

--- a/tests/test_data/pyproject.json
+++ b/tests/test_data/pyproject.json
@@ -1,0 +1,54 @@
+{
+    "tool": {
+      "poetry": {
+        "name": "my_project",
+        "version": "0.1.0",
+        "description": "A detailed description of my project.",
+        "authors": ["John Doe <john.doe@example.com>"],
+        "license": "MIT",
+        "readme": "README.md",
+        "homepage": "https://example.com",
+        "repository": "https://github.com/example/my_project",
+        "documentation": "https://docs.example.com",
+        "keywords": ["example", "project", "poetry"],
+        "dependencies": {
+          "python": "^3.9",
+          "requests": "^2.25.1",
+          "numpy": "^1.20.3"
+        },
+        "dev-dependencies": {
+          "pytest": "^6.2.4",
+          "black": "^21.6b0",
+          "isort": "^5.9.3"
+        }
+      },
+      "black": {
+        "line-length": 88,
+        "target-version": ["py39"],
+        "exclude": "/(\n    \\.eggs\n  | \\.git\n  | \\.hg\n  | \\.mypy_cache\n  | \\.tox\n  | \\.venv\n  | _build\n  | buck-out\n  | build\n  | dist\n)/"
+      },
+      "isort": {
+        "profile": "black"
+      },
+      "pytest": {
+        "ini_options": {
+          "minversion": "6.0",
+          "addopts": "-ra -q",
+          "testpaths": ["tests"]
+        }
+      },
+      "mypy": {
+        "python_version": "3.9",
+        "warn_unused_configs": true,
+        "warn_unused_ignores": true
+      },
+      "pydocstyle": {
+        "convention": "numpy",
+        "add_ignore": ["D105"]
+      }
+    },
+    "build-system": {
+      "requires": ["poetry-core>=1.0.0"],
+      "build-backend": "poetry.core.masonry.api"
+    }
+  }

--- a/tests/test_data/pyproject.toml
+++ b/tests/test_data/pyproject.toml
@@ -1,0 +1,60 @@
+[tool.poetry]
+name = "my_project"
+version = "0.1.0"
+description = "A detailed description of my project."
+authors = ["John Doe <john.doe@example.com>"]
+license = "MIT"
+readme = "README.md"
+homepage = "https://example.com"
+repository = "https://github.com/example/my_project"
+documentation = "https://docs.example.com"
+keywords = ["example", "project", "poetry"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+requests = "^2.25.1"
+numpy = "^1.20.3"
+
+[tool.poetry.dev-dependencies]
+pytest = "^6.2.4"
+black = "^21.6b0"
+isort = "^5.9.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ['py39']
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = ["tests"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_unused_configs = true
+warn_unused_ignores = true
+
+[tool.pydocstyle]
+convention = "numpy"
+add_ignore = ["D105"]

--- a/tests/test_data/pyproject.yaml
+++ b/tests/test_data/pyproject.yaml
@@ -1,0 +1,61 @@
+tool:
+  poetry:
+    name: my_project
+    version: 0.1.0
+    description: A detailed description of my project.
+    authors:
+      - John Doe <john.doe@example.com>
+    license: MIT
+    readme: README.md
+    homepage: https://example.com
+    repository: https://github.com/example/my_project
+    documentation: https://docs.example.com
+    keywords:
+      - example
+      - project
+      - poetry
+    dependencies:
+      python: "^3.9"
+      requests: "^2.25.1"
+      numpy: "^1.20.3"
+    dev-dependencies:
+      pytest: "^6.2.4"
+      black: "^21.6b0"
+      isort: "^5.9.3"
+  black:
+    line-length: 88
+    target-version:
+      - py39
+    exclude: |
+      /(
+          \.eggs
+        | \.git
+        | \.hg
+        | \.mypy_cache
+        | \.tox
+        | \.venv
+        | _build
+        | buck-out
+        | build
+        | dist
+      )/
+  isort:
+    profile: black
+  pytest:
+    ini_options:
+      minversion: "6.0"
+      addopts: "-ra -q"
+      testpaths:
+        - tests
+  mypy:
+    python_version: 3.9
+    warn_unused_configs: true
+    warn_unused_ignores: true
+  pydocstyle:
+    convention: numpy
+    add_ignore:
+      - D105
+build-system:
+  requires:
+    - poetry-core>=1.0.0
+  build-backend: poetry.core.masonry.api

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -1,0 +1,136 @@
+use config_converter::{DecodeError, Decoder};
+
+#[test]
+fn test_invalid_toml() {
+    let test_toml: &str = r#"
+    [package
+    "#;
+
+    let result = Decoder::TOML.decode_from_str(test_toml);
+
+    // Check that an error is returned
+    assert!(result.is_err());
+
+    let expected_error = "TOML parse error at line 2, column 13";
+    if let Err(DecodeError::Toml(err)) = result {
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains(expected_error),
+            "Unexpected error: {}. Expected it to contain: {}",
+            err_str,
+            expected_error
+        );
+    } else {
+        panic!("Expected a TOML parse error");
+    }
+}
+
+macro_rules! decode_tests {
+    ($($name:ident: ($filename:expr, $decoder:expr),)*) => {
+    $(
+        #[test]
+        fn $name() {
+            let file_path = format!("tests/test_data/{}", $filename);
+            let decoded = $decoder.decode_file(&file_path).unwrap();
+
+            assert_eq!(
+                decoded["tool"]["poetry"]["name"].as_str().unwrap(),
+                "my_project"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["version"].as_str().unwrap(),
+                "0.1.0"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["description"].as_str().unwrap(),
+                "A detailed description of my project."
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["authors"][0].as_str().unwrap(),
+                "John Doe <john.doe@example.com>"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["license"].as_str().unwrap(),
+                "MIT"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["readme"].as_str().unwrap(),
+                "README.md"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["homepage"].as_str().unwrap(),
+                "https://example.com"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["repository"].as_str().unwrap(),
+                "https://github.com/example/my_project"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["documentation"].as_str().unwrap(),
+                "https://docs.example.com"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["keywords"][0].as_str().unwrap(),
+                "example"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["keywords"][1].as_str().unwrap(),
+                "project"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["keywords"][2].as_str().unwrap(),
+                "poetry"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dependencies"]["python"]
+                    .as_str()
+                    .unwrap(),
+                "^3.9"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dependencies"]["requests"]
+                    .as_str()
+                    .unwrap(),
+                "^2.25.1"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dependencies"]["numpy"]
+                    .as_str()
+                    .unwrap(),
+                "^1.20.3"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dev-dependencies"]["pytest"]
+                    .as_str()
+                    .unwrap(),
+                "^6.2.4"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dev-dependencies"]["black"]
+                    .as_str()
+                    .unwrap(),
+                "^21.6b0"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dev-dependencies"]["isort"]
+                    .as_str()
+                    .unwrap(),
+                "^5.9.3"
+            );
+        }
+    )*
+    }
+}
+
+decode_tests! {
+    test_read_toml_file: ("pyproject.toml", Decoder::TOML),
+    test_read_yaml_file: ("pyproject.yaml", Decoder::YAML),
+    test_read_json_file: ("pyproject.json", Decoder::JSON),
+}
+
+#[test]
+fn test_decode_fails_for_invalid_file_extension() {
+    let decoder = Decoder::TOML;
+    let result = decoder.decode_file("invalid_file.txt");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Includes:
- `DecodeError` enum for categorizing and propagating errors
- `Decoder` enum for determining the appropriate file format decoder
- Functionality to read and decode files based on their extension
- Unit tests for decoding functionality and corresponding test data