### PR TITLE
Feature/add initial cli skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "config_converter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# [workspace]
+# members = ["config_transformer"]
+
+# [profile.dev]
+# rustflags = ["-Dwarnings"]
+
+# [profile.release]
+# rustflags = ["-Dwarnings"]
+
+# [features]
+# clippy = ["clippy"]
+
+[dependencies]
+toml = "0.8.14"
+clap = { version = "4.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+serde_yaml = "0.8"
+strum_macros = "0.26"
+
+[dev-dependencies]
+tempfile = "3.3"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,32 @@
+# Turn on pedantic lints, which are more stringent and cover more cases.
+warn = [
+    "clippy::pedantic"
+]
+
+# Turn on nursery lints, which are new lints that may not be as stable.
+warn = [
+    "clippy::nursery"
+]
+
+allow = [
+    "clippy::module_name_repetitions",  # Allow module name repetitions
+    "clippy::too_many_lines",           # Allow functions to have many lines
+    "clippy::missing_errors_doc",       # Allow missing documentation for error return types
+    "clippy::missing_panics_doc",       # Allow missing documentation for panic conditions
+]
+
+deny = [
+    "clippy::unwrap_used",              # Deny usage of unwrap
+    "clippy::expect_used",              # Deny usage of expect
+    "clippy::wildcard_imports",         # Deny wildcard imports
+]
+
+# For example, limit the number of arguments allowed in a function.
+clippy::too_many_arguments_threshold = 7
+clippy::cyclomatic_complexity_threshold = 15
+
+# Customize the behaviour of cognitive complexity lint.
+clippy::cognitive_complexity_threshold = 25
+
+# Restrict the number of allowed lines in a function.
+clippy::function_too_large_threshold = 100

--- a/src/cli/interface.rs
+++ b/src/cli/interface.rs
@@ -1,0 +1,72 @@
+use crate::decode::Decoder;
+use crate::encode::Encoder;
+use clap::{Parser, Subcommand};
+
+/// Transforms configuration files between different formats.
+/// Provides a safer way to convert and manipulate configuration files,
+/// ensuring data integrity and preventing accidental data loss.
+#[derive(Parser)]
+#[command(
+    name = "config_converter",
+    about = "Transforms configuration files between different formats.",
+    version = "1.0"
+)]
+pub struct CLI {
+    #[command(subcommand)]
+    pub converters: Converters,
+}
+
+#[derive(Parser)]
+pub struct InputOutput {
+    /// Input file path
+    #[arg(required = true)]
+    pub input: String,
+    /// Output file path
+    #[arg(short, long)]
+    pub write: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub enum Converters {
+    // TOML CONVERTERS //
+    /// Convert from TOML to JSON.
+    TomlToJson(InputOutput),
+    /// Convert from TOML to YAML.
+    TomlToYaml(InputOutput),
+
+    // JSON CONVERTERS //
+    /// Convert from JSON to TOML.
+    JsonToToml(InputOutput),
+    /// Convert from JSON to YAML.
+    JsonToYaml(InputOutput),
+
+    // YAML CONVERTERS //
+    /// Convert from YAML JSON.
+    YamlToJson(InputOutput),
+    /// Convert from YAML TOML.
+    YamlToToml(InputOutput),
+}
+
+impl Converters {
+    pub fn conversion_types(&self) -> (Decoder, Encoder) {
+        match self {
+            Converters::TomlToJson(_) => (Decoder::TOML, Encoder::JSON),
+            Converters::TomlToYaml(_) => (Decoder::TOML, Encoder::YAML),
+            Converters::JsonToToml(_) => (Decoder::JSON, Encoder::TOML),
+            Converters::JsonToYaml(_) => (Decoder::JSON, Encoder::YAML),
+            Converters::YamlToJson(_) => (Decoder::YAML, Encoder::JSON),
+            Converters::YamlToToml(_) => (Decoder::YAML, Encoder::TOML),
+        }
+    }
+
+    pub fn get_input_output(&self) -> &InputOutput {
+        match self {
+            Converters::TomlToJson(input_output) => input_output,
+            Converters::TomlToYaml(input_output) => input_output,
+            Converters::JsonToToml(input_output) => input_output,
+            Converters::JsonToYaml(input_output) => input_output,
+            Converters::YamlToJson(input_output) => input_output,
+            Converters::YamlToToml(input_output) => input_output,
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,57 @@
+mod interface;
+
+use crate::decode::Decoder;
+use crate::encode::Encoder;
+use clap::Parser;
+use interface::{Converters, InputOutput, CLI};
+
+pub fn run_cli() {
+    let cli_args = CLI::parse();
+    let (from, to) = cli_args.converters.conversion_types();
+    let io = cli_args.converters.get_input_output();
+
+    let user_message = create_conversion_message(&from.to_string(), &to.to_string(), &io);
+
+    // Print a message declaring the conversion about to take place
+    println!("{}", user_message);
+
+    convert_config_file(from, to, io);
+}
+
+fn create_conversion_message(from: &str, to: &str, io: &InputOutput) -> String {
+    let write_location_msg = if let Some(out) = &io.write {
+        format!(" and outputting to '{}'", out)
+    } else {
+        String::from(".")
+    };
+
+    let main_str = format!(
+        "🧙 Converting '{}' to {}{}",
+        &io.input, to, write_location_msg,
+    );
+    let line_padding = "-".repeat(main_str.chars().count());
+
+    format!("{}\n{}\n{}", line_padding, main_str, line_padding)
+}
+
+fn convert_config_file(from: Decoder, to: Encoder, io: &InputOutput) {
+    match from.decode_file(&io.input) {
+        Ok(decoded) => {
+            if let Some(output_path) = &io.write {
+                match to.encode_to_file(&decoded, output_path) {
+                    Ok(_) => println!(
+                        "🎉 Conversion successful! Output written to '{}'",
+                        output_path
+                    ),
+                    Err(e) => eprintln!("🚨 Conversion failed: {}", e),
+                }
+            } else {
+                match to.encode_to_str(&decoded) {
+                    Ok(encoded_str) => println!("{}", encoded_str),
+                    Err(e) => eprintln!("🚨 Conversion failed: {}", e),
+                }
+            }
+        }
+        Err(e) => eprintln!("🚨 Conversion failed: {}", e),
+    }
+}

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,0 +1,66 @@
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+use std::fs;
+use thiserror::Error;
+use toml::Value as TomlValue;
+
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("-------------------------------------\n{0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("-------------------------------------\n{0}")]
+    Json(#[from] serde_json::Error),
+    #[error("-------------------------------------\n{0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error("File read error: {0}")]
+    FileRead(#[from] std::io::Error),
+}
+
+// TODO: INI, YAML
+#[derive(strum_macros::Display)]
+pub enum Decoder {
+    TOML,
+    JSON,
+    YAML,
+}
+
+impl Decoder {
+    fn verify_file_extension(&self, file_path: &str) -> bool {
+        match self {
+            Decoder::TOML => file_path.ends_with(".toml"),
+            Decoder::JSON => file_path.ends_with(".json"),
+            Decoder::YAML => file_path.ends_with(".yaml") || file_path.ends_with(".yml"),
+        }
+    }
+
+    pub fn decode_from_str(&self, content: &str) -> Result<JsonValue, DecodeError> {
+        match self {
+            Decoder::TOML => {
+                let toml_value: TomlValue = content.parse()?;
+                let json_value = serde_json::to_value(toml_value)?;
+                Ok(json_value)
+            }
+            Decoder::JSON => {
+                let json_value: JsonValue = serde_json::from_str(content)?;
+                Ok(json_value)
+            }
+            Decoder::YAML => {
+                let yaml_value: YamlValue = serde_yaml::from_str(content)?;
+                let json_value = serde_json::to_value(yaml_value)?;
+                Ok(json_value)
+            }
+        }
+    }
+
+    pub fn decode_file(&self, file_path: &str) -> Result<JsonValue, DecodeError> {
+        if !self.verify_file_extension(file_path) {
+            return Err(DecodeError::FileRead(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid file extension",
+            )));
+        }
+
+        let content = fs::read_to_string(file_path)?;
+        self.decode_from_str(&content)
+    }
+}

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,0 +1,52 @@
+use serde_json::Value as JsonValue;
+use std::fs;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum EncodeError {
+    #[error("TOML encode error: {0}")]
+    Toml(#[from] toml::ser::Error),
+    #[error("JSON encode error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("YAML encode error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error("File write error: {0}")]
+    FileWrite(#[from] std::io::Error),
+}
+
+#[derive(strum_macros::Display)]
+pub enum Encoder {
+    TOML,
+    JSON,
+    YAML,
+}
+
+impl Encoder {
+    pub fn encode_to_str(&self, json_value: &JsonValue) -> Result<String, EncodeError> {
+        match self {
+            Encoder::TOML => {
+                let toml_value: toml::Value = serde_json::from_value(json_value.clone())?;
+                let toml_string = toml::to_string(&toml_value)?;
+                Ok(toml_string)
+            }
+            Encoder::JSON => {
+                let json_string = serde_json::to_string_pretty(json_value)?;
+                Ok(json_string)
+            }
+            Encoder::YAML => {
+                let yaml_value: serde_yaml::Value = serde_json::from_value(json_value.clone())?;
+                let yaml_string = serde_yaml::to_string(&yaml_value)?;
+                Ok(yaml_string)
+            }
+        }
+    }
+
+    pub fn encode_to_file(
+        &self,
+        json_value: &JsonValue,
+        file_path: &str,
+    ) -> Result<(), EncodeError> {
+        let content = self.encode_to_str(json_value)?;
+        fs::write(file_path, content).map_err(EncodeError::FileWrite)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+mod cli;
+mod decode;
+mod encode;
+
+pub use decode::{DecodeError, Decoder};
+pub use encode::{EncodeError, Encoder};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,64 @@
+mod cli;
+mod decode;
+mod encode;
+
+use cli::run_cli;
+use decode::Decoder;
+use encode::Encoder;
+use serde_json;
+use toml;
+
+pub use decode::DecodeError;
+pub use encode::EncodeError;
+
+// fn toml_to_json(toml_str: &str) -> Result<String, Box<dyn std::error::Error>> {
+//     // Parse TOML string into TomlValue
+//     let toml_value: toml::Value = toml_str.parse()?;
+//     println!("TOML:\n{:?}", toml_value);
+
+//     // Convert TomlValue to JSON string
+//     let json_string = serde_json::to_string_pretty(&toml_value)?;
+//     Ok(json_string)
+// }
+
+// fn main() {
+//     let toml_str = r#"
+//         [package]
+//         name = "example"
+//         version = "0.1.0"
+//     "#;
+
+//     match toml_to_json(toml_str) {
+//         Ok(json) => println!("{}", json),
+//         Err(e) => eprintln!("Error: {}", e),
+//     }
+// }
+
+fn main() {
+    // let test_toml: &str = r#"
+    // [package
+    // "#;
+
+    // let result = Decoder::TOML.decode_from_str(test_toml);
+    // println!("{:#?}", result);
+    // match result {
+    //     Ok(_) => println!("No error"),
+    //     Err(e) => eprintln!("{}", e),
+    // }
+
+    // println!("{}", Decoder::TOML.to_string());
+    run_cli();
+
+    // let toml_str = r#"
+    //     [package]
+    //     name = "example"
+    //     version = "0.1.0"
+    // "#;
+
+    // // let json_value = decode::decode_from_str(&Decoder::TOML, toml_str).unwrap();
+    // let json_value = Decoder::TOML.decode_from_str(toml_str).unwrap();
+    // println!("DECODED VALUE:\n{}", json_value);
+
+    // let json_out = Encoder::JSON.encode_to_str(&json_value).unwrap();
+    // println!("ENCODED VALUE:\n{}", json_out);
+}

--- a/tests/test_data/pyproject.json
+++ b/tests/test_data/pyproject.json
@@ -1,0 +1,54 @@
+{
+    "tool": {
+      "poetry": {
+        "name": "my_project",
+        "version": "0.1.0",
+        "description": "A detailed description of my project.",
+        "authors": ["John Doe <john.doe@example.com>"],
+        "license": "MIT",
+        "readme": "README.md",
+        "homepage": "https://example.com",
+        "repository": "https://github.com/example/my_project",
+        "documentation": "https://docs.example.com",
+        "keywords": ["example", "project", "poetry"],
+        "dependencies": {
+          "python": "^3.9",
+          "requests": "^2.25.1",
+          "numpy": "^1.20.3"
+        },
+        "dev-dependencies": {
+          "pytest": "^6.2.4",
+          "black": "^21.6b0",
+          "isort": "^5.9.3"
+        }
+      },
+      "black": {
+        "line-length": 88,
+        "target-version": ["py39"],
+        "exclude": "/(\n    \\.eggs\n  | \\.git\n  | \\.hg\n  | \\.mypy_cache\n  | \\.tox\n  | \\.venv\n  | _build\n  | buck-out\n  | build\n  | dist\n)/"
+      },
+      "isort": {
+        "profile": "black"
+      },
+      "pytest": {
+        "ini_options": {
+          "minversion": "6.0",
+          "addopts": "-ra -q",
+          "testpaths": ["tests"]
+        }
+      },
+      "mypy": {
+        "python_version": "3.9",
+        "warn_unused_configs": true,
+        "warn_unused_ignores": true
+      },
+      "pydocstyle": {
+        "convention": "numpy",
+        "add_ignore": ["D105"]
+      }
+    },
+    "build-system": {
+      "requires": ["poetry-core>=1.0.0"],
+      "build-backend": "poetry.core.masonry.api"
+    }
+  }

--- a/tests/test_data/pyproject.toml
+++ b/tests/test_data/pyproject.toml
@@ -1,0 +1,60 @@
+[tool.poetry]
+name = "my_project"
+version = "0.1.0"
+description = "A detailed description of my project."
+authors = ["John Doe <john.doe@example.com>"]
+license = "MIT"
+readme = "README.md"
+homepage = "https://example.com"
+repository = "https://github.com/example/my_project"
+documentation = "https://docs.example.com"
+keywords = ["example", "project", "poetry"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+requests = "^2.25.1"
+numpy = "^1.20.3"
+
+[tool.poetry.dev-dependencies]
+pytest = "^6.2.4"
+black = "^21.6b0"
+isort = "^5.9.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ['py39']
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = ["tests"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_unused_configs = true
+warn_unused_ignores = true
+
+[tool.pydocstyle]
+convention = "numpy"
+add_ignore = ["D105"]

--- a/tests/test_data/pyproject.yaml
+++ b/tests/test_data/pyproject.yaml
@@ -1,0 +1,61 @@
+tool:
+  poetry:
+    name: my_project
+    version: 0.1.0
+    description: A detailed description of my project.
+    authors:
+      - John Doe <john.doe@example.com>
+    license: MIT
+    readme: README.md
+    homepage: https://example.com
+    repository: https://github.com/example/my_project
+    documentation: https://docs.example.com
+    keywords:
+      - example
+      - project
+      - poetry
+    dependencies:
+      python: "^3.9"
+      requests: "^2.25.1"
+      numpy: "^1.20.3"
+    dev-dependencies:
+      pytest: "^6.2.4"
+      black: "^21.6b0"
+      isort: "^5.9.3"
+  black:
+    line-length: 88
+    target-version:
+      - py39
+    exclude: |
+      /(
+          \.eggs
+        | \.git
+        | \.hg
+        | \.mypy_cache
+        | \.tox
+        | \.venv
+        | _build
+        | buck-out
+        | build
+        | dist
+      )/
+  isort:
+    profile: black
+  pytest:
+    ini_options:
+      minversion: "6.0"
+      addopts: "-ra -q"
+      testpaths:
+        - tests
+  mypy:
+    python_version: 3.9
+    warn_unused_configs: true
+    warn_unused_ignores: true
+  pydocstyle:
+    convention: numpy
+    add_ignore:
+      - D105
+build-system:
+  requires:
+    - poetry-core>=1.0.0
+  build-backend: poetry.core.masonry.api

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -1,0 +1,136 @@
+use config_converter::{DecodeError, Decoder};
+
+#[test]
+fn test_invalid_toml() {
+    let test_toml: &str = r#"
+    [package
+    "#;
+
+    let result = Decoder::TOML.decode_from_str(test_toml);
+
+    // Check that an error is returned
+    assert!(result.is_err());
+
+    let expected_error = "TOML parse error at line 2, column 13";
+    if let Err(DecodeError::Toml(err)) = result {
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains(expected_error),
+            "Unexpected error: {}. Expected it to contain: {}",
+            err_str,
+            expected_error
+        );
+    } else {
+        panic!("Expected a TOML parse error");
+    }
+}
+
+macro_rules! decode_tests {
+    ($($name:ident: ($filename:expr, $decoder:expr),)*) => {
+    $(
+        #[test]
+        fn $name() {
+            let file_path = format!("tests/test_data/{}", $filename);
+            let decoded = $decoder.decode_file(&file_path).unwrap();
+
+            assert_eq!(
+                decoded["tool"]["poetry"]["name"].as_str().unwrap(),
+                "my_project"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["version"].as_str().unwrap(),
+                "0.1.0"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["description"].as_str().unwrap(),
+                "A detailed description of my project."
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["authors"][0].as_str().unwrap(),
+                "John Doe <john.doe@example.com>"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["license"].as_str().unwrap(),
+                "MIT"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["readme"].as_str().unwrap(),
+                "README.md"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["homepage"].as_str().unwrap(),
+                "https://example.com"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["repository"].as_str().unwrap(),
+                "https://github.com/example/my_project"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["documentation"].as_str().unwrap(),
+                "https://docs.example.com"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["keywords"][0].as_str().unwrap(),
+                "example"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["keywords"][1].as_str().unwrap(),
+                "project"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["keywords"][2].as_str().unwrap(),
+                "poetry"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dependencies"]["python"]
+                    .as_str()
+                    .unwrap(),
+                "^3.9"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dependencies"]["requests"]
+                    .as_str()
+                    .unwrap(),
+                "^2.25.1"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dependencies"]["numpy"]
+                    .as_str()
+                    .unwrap(),
+                "^1.20.3"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dev-dependencies"]["pytest"]
+                    .as_str()
+                    .unwrap(),
+                "^6.2.4"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dev-dependencies"]["black"]
+                    .as_str()
+                    .unwrap(),
+                "^21.6b0"
+            );
+            assert_eq!(
+                decoded["tool"]["poetry"]["dev-dependencies"]["isort"]
+                    .as_str()
+                    .unwrap(),
+                "^5.9.3"
+            );
+        }
+    )*
+    }
+}
+
+decode_tests! {
+    test_read_toml_file: ("pyproject.toml", Decoder::TOML),
+    test_read_yaml_file: ("pyproject.yaml", Decoder::YAML),
+    test_read_json_file: ("pyproject.json", Decoder::JSON),
+}
+
+#[test]
+fn test_decode_fails_for_invalid_file_extension() {
+    let decoder = Decoder::TOML;
+    let result = decoder.decode_file("invalid_file.txt");
+    assert!(result.is_err());
+}

--- a/tests/test_encode.rs
+++ b/tests/test_encode.rs
@@ -1,0 +1,63 @@
+use config_converter::Encoder;
+use std::fs;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_encode_to_toml_str() {
+    let json_value = serde_json::json!({
+        "package": {
+            "name": "hello_world",
+            "version": "0.1.0"
+        }
+    });
+    let encoded_toml = Encoder::TOML.encode_to_str(&json_value).unwrap();
+    assert!(encoded_toml.contains("name = \"hello_world\""));
+}
+
+#[test]
+fn test_encode_to_json_str() {
+    let json_value = serde_json::json!({
+        "name": "John Doe",
+        "age": 43,
+        "phones": [
+            "+44 1234567",
+            "+44 2345678"
+        ]
+    });
+    let encoded_json = Encoder::JSON.encode_to_str(&json_value).unwrap();
+    assert!(encoded_json.contains("\"name\": \"John Doe\""));
+}
+
+#[test]
+fn test_encode_to_yaml_str() {
+    let json_value = serde_json::json!({
+        "name": "John Doe",
+        "age": 43,
+        "phones": [
+            "+44 1234567",
+            "+44 2345678"
+        ]
+    });
+    let encoded_yaml = Encoder::YAML.encode_to_str(&json_value).unwrap();
+    assert!(encoded_yaml.contains("name: John Doe"));
+}
+
+#[test]
+fn test_encode_to_file() {
+    let json_value = serde_json::json!({
+        "package": {
+            "name": "hello_world",
+            "version": "0.1.0"
+        }
+    });
+
+    // Create a temporary file
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    Encoder::TOML
+        .encode_to_file(&json_value, file_path)
+        .unwrap();
+    let encoded_content = fs::read_to_string(file_path).unwrap();
+    assert!(encoded_content.contains("name = \"hello_world\""));
+}


### PR DESCRIPTION
Includes:
- `DecodeError` enum for categorizing and propagating errors
- `Decoder` enum for determining the appropriate file format decoder
- Functionality to read and decode files based on their extension
- Unit tests for decoding functionality and corresponding test data