### PR TITLE
build(ci): add GitHub Actions for building and releasing binaries

### DIFF
--- a/.github/workflows/release/create_binaries.yml
+++ b/.github/workflows/release/create_binaries.yml
@@ -1,0 +1,48 @@
+name: Build and upload binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        target:
+          - x86_64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+
+      - name: Build binary for ${{ matrix.target }}
+        run: |
+          echo "Building for target ${{ matrix.target }} on OS ${{ matrix.os }}"
+          cargo build --release --target ${{ matrix.target }}
+
+      - name: Upload binary for ${{ matrix.target }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ConfigConverter-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/config_converter
+          retention-days: 5

--- a/.github/workflows/release/create_release.yml
+++ b/.github/workflows/release/create_release.yml
@@ -1,0 +1,73 @@
+name: Create Release
+
+on:
+  workflow_run:
+    workflows: ["Build and upload binaries"]
+    types:
+      - completed
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Release Assets (Linux)
+        uses: actions/download-artifact@v3
+        with:
+          name: ConfigConverter-x86_64-unknown-linux-musl
+          path: ./dist/linux
+
+      - name: Download Release Assets (macOS)
+        uses: actions/download-artifact@v3
+        with:
+          name: ConfigConverter-x86_64-apple-darwin
+          path: ./dist/macos
+
+      - name: Download Release Assets (Windows)
+        uses: actions/download-artifact@v3
+        with:
+          name: ConfigConverter-x86_64-pc-windows-gnu
+          path: ./dist/windows
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/linux/ConfigConverter
+          asset_name: config_converter-x86_64-unknown-linux-musl
+          asset_content_type: application/octet-stream
+
+      - name: Upload macOS Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/macos/ConfigConverter
+          asset_name: config_converter-x86_64-apple-darwin
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/windows/ConfigConverter.exe
+          asset_name: config_converter-x86_64-pc-windows-gnu
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
- Create a workflow to build binaries for multiple platforms and upload them as artifacts.
- Add a workflow to create a GitHub release and upload the built binaries as release assets.
- Ensure proper naming and paths for release assets in the release workflow.