### PR TITLE
refactor(cli): improve handling of optional write argument

### DIFF
--- a/src/cli/interface.rs
+++ b/src/cli/interface.rs
@@ -6,46 +6,40 @@ use clap::{Parser, Subcommand};
 /// ensuring data integrity and preventing accidental data loss.
 #[derive(Parser)]
 #[command(
-    name = "config_converter",
+    name = "ConfigConverter",
     about = "Transforms configuration files between different formats.",
     version = "1.0"
 )]
 pub struct CLI {
+    /// Input file path
+    #[arg(required = true)]
+    pub input: String,
+
+    /// Output file path
+    #[arg(short, long)]
+    pub write: Option<String>,
+
     #[command(subcommand)]
     pub converters: Converters,
 }
 
-#[derive(Parser)]
-pub struct InputOutput {
-    /// Input file path
-    #[arg(required = true)]
-    pub input: String,
-    /// Output file path
-    #[arg(short, long)]
-    pub write: Option<String>,
-}
-
 #[derive(Subcommand)]
 pub enum Converters {
-    ToTOML(InputOutput),
-    ToJSON(InputOutput),
-    ToYAML(InputOutput),
+    ToTOML,
+    ToJSON,
+    ToYAML,
 }
 
-impl Converters {
+impl CLI {
     pub fn get_encoder(&self) -> Encoder {
-        match self {
-            Converters::ToTOML(_) => Encoder::TOML,
-            Converters::ToJSON(_) => Encoder::JSON,
-            Converters::ToYAML(_) => Encoder::YAML,
+        match self.converters {
+            Converters::ToTOML => Encoder::TOML,
+            Converters::ToJSON => Encoder::JSON,
+            Converters::ToYAML => Encoder::YAML,
         }
     }
 
-    pub fn get_input_output(&self) -> &InputOutput {
-        match self {
-            Converters::ToTOML(input_output) => input_output,
-            Converters::ToJSON(input_output) => input_output,
-            Converters::ToYAML(input_output) => input_output,
-        }
+    pub fn get_input_output(&self) -> (&String, &Option<String>) {
+        (&self.input, &self.write)
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,7 @@ mod interface;
 use crate::decode::{file_path_to_decoder, Decoder};
 use crate::encode::Encoder;
 use clap::Parser;
-use interface::{Converters, InputOutput, CLI};
+use interface::CLI;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 
@@ -28,30 +28,28 @@ impl Error for CliError {}
 
 pub fn run_cli() -> Result<String, Box<dyn Error>> {
     let cli_args = CLI::parse();
-    let io = cli_args.converters.get_input_output();
+    let (input, write) = cli_args.get_input_output();
     let decoder =
-        file_path_to_decoder(&io.input).map_err(|e| CliError::DecoderError(e.to_string()))?;
-    let encoder = cli_args.converters.get_encoder();
+        file_path_to_decoder(&input).map_err(|e| CliError::DecoderError(e.to_string()))?;
+    let encoder = cli_args.get_encoder();
 
-    let user_message = create_conversion_message(&decoder.to_string(), &encoder.to_string(), &io);
+    let user_message =
+        create_conversion_message(&decoder.to_string(), &encoder.to_string(), write.as_deref());
 
-    let config_success_message = convert_config_file(decoder, encoder, io)
+    let config_success_message = convert_config_file(decoder, encoder, &input, write.as_deref())
         .map_err(|e| CliError::ConversionError(e.to_string()))?;
 
     Ok(format!("{}\n{}", user_message, config_success_message))
 }
 
-fn create_conversion_message(from: &str, to: &str, io: &InputOutput) -> String {
-    let write_location_msg = if let Some(out) = &io.write {
+fn create_conversion_message(from: &str, to: &str, write: Option<&str>) -> String {
+    let write_location_msg = if let Some(out) = write {
         format!(" and outputting to '{}'", out)
     } else {
         String::from(".")
     };
 
-    let main_str = format!(
-        "🧙 Converting '{}' to {}{}",
-        &io.input, to, write_location_msg,
-    );
+    let main_str = format!("🧙 Converting '{}' to {}{}", from, to, write_location_msg,);
     let line_padding = "-".repeat(main_str.chars().count());
 
     format!("{}\n{}\n{}", line_padding, main_str, line_padding)
@@ -60,10 +58,11 @@ fn create_conversion_message(from: &str, to: &str, io: &InputOutput) -> String {
 fn convert_config_file(
     from: Decoder,
     to: Encoder,
-    io: &InputOutput,
+    input: &str,
+    write: Option<&str>,
 ) -> Result<String, Box<dyn Error>> {
-    let decoded = from.decode_file(&io.input)?;
-    if let Some(output_path) = &io.write {
+    let decoded = from.decode_file(input)?;
+    if let Some(output_path) = write {
         to.encode_to_file(&decoded, output_path)?;
         Ok(format!(
             "🎉 Conversion successful! Output written to '{}'",


### PR DESCRIPTION
- Changed clippy internals so that `input` and `write` appear in --help.
- Updated `create_conversion_message` to accept and handle `Option<&str>` for the `write` parameter.
- Fixed `create_conversion_message` to correctly use the `from` argument.
- Updated `convert_config_file` to accept `Option<&str>` for the `write` parameter.